### PR TITLE
`azurerm_key_vault_secret` - add `value_wo` and `value_wo_version`

### DIFF
--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -76,6 +76,7 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				RequiredWith: []string{"value_wo"},
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 
 			"content_type": {

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
@@ -57,9 +58,24 @@ func resourceKeyVaultSecret() *pluginsdk.Resource {
 			"key_vault_id": commonschema.ResourceIDReferenceRequiredForceNew(&commonids.KeyVaultId{}),
 
 			"value": {
-				Type:      pluginsdk.TypeString,
-				Required:  true,
-				Sensitive: true,
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"value", "value_wo"},
+			},
+
+			"value_wo": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				WriteOnly:    true,
+				RequiredWith: []string{"value_wo_version"},
+				ExactlyOneOf: []string{"value", "value_wo"},
+			},
+
+			"value_wo_version": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"value_wo"},
 			},
 
 			"content_type": {
@@ -145,6 +161,15 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	value := d.Get("value").(string)
+
+	valueWo, err := pluginsdk.GetWriteOnly(d, "value_wo", cty.String)
+	if err != nil {
+		return err
+	}
+	if !valueWo.IsNull() {
+		value = valueWo.AsString()
+	}
+
 	contentType := d.Get("content_type").(string)
 	t := d.Get("tags").(map[string]interface{})
 
@@ -271,7 +296,14 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		secretAttributes.Expires = &expirationUnixTime
 	}
 
-	if d.HasChange("value") {
+	if d.HasChanges("value", "value_wo_version") {
+		valueWo, err := pluginsdk.GetWriteOnly(d, "value_wo", cty.String)
+		if err != nil {
+			return err
+		}
+		if !valueWo.IsNull() {
+			value = valueWo.AsString()
+		}
 		// for changing the value of the secret we need to create a new version
 		parameters := keyvault.SecretSetParameters{
 			Value:            utils.String(value),
@@ -368,9 +400,14 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 	d.Set("name", respID.Name)
 	d.Set("value", resp.Value)
+	// Unset value if is a write-only value
+	if _, ok := d.GetOk("value_wo_version"); ok {
+		d.Set("value", nil)
+	}
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
 	d.Set("versionless_id", id.VersionlessID())
+	d.Set("value_wo_version", d.Get("value_wo_version").(int))
 
 	if attributes := resp.Attributes; attributes != nil {
 		if v := attributes.NotBefore; v != nil {

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -10,9 +10,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -36,6 +40,77 @@ func TestAccKeyVaultSecret_basic(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccKeyVaultSecret_writeOnlyValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
+	r := KeyVaultSecretResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []acceptance.TestStep{
+			{
+				Config: r.writeOnlyValue(data, "rick-and-morty", 1),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").IsEmpty(),
+					check.That(data.ResourceName).Key("value_wo_version").HasValue("1"),
+				),
+			},
+			data.ImportStep("value", "value_wo_version"),
+			{
+				Config: r.writeOnlyValue(data, "szechuan", 2),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").IsEmpty(),
+					check.That(data.ResourceName).Key("value_wo_version").HasValue("2"),
+				),
+			},
+			data.ImportStep("value", "value_wo_version"),
+		},
+	})
+}
+
+func TestAccKeyVaultSecret_updateToWriteOnlyValue(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
+	r := KeyVaultSecretResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []acceptance.TestStep{
+			{
+				Config: r.basic(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: r.writeOnlyValue(data, "szechuan", 1),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").IsEmpty(),
+					check.That(data.ResourceName).Key("value_wo_version").HasValue("1"),
+				),
+			},
+			data.ImportStep("value", "value_wo_version"),
+			{
+				Config: r.basic(data),
+				Check: acceptance.ComposeTestCheckFunc(
+					check.That(data.ResourceName).ExistsInAzure(r),
+					check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				),
+			},
+			data.ImportStep(),
+		},
 	})
 }
 
@@ -326,6 +401,23 @@ resource "azurerm_key_vault_secret" "test" {
   key_vault_id = azurerm_key_vault.test.id
 }
 `, r.template(data), data.RandomString)
+}
+
+func (r KeyVaultSecretResource) writeOnlyValue(data acceptance.TestData, secret string, version int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_secret" "test" {
+  name              = "secret-%s"
+  value_wo          = "%s"
+  value_wo_version  = %d
+  key_vault_id      = azurerm_key_vault.test.id
+}
+`, r.template(data), data.RandomString, secret, version)
 }
 
 func (r KeyVaultSecretResource) updateTags(data acceptance.TestData) string {

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -412,10 +412,10 @@ provider "azurerm" {
 %s
 
 resource "azurerm_key_vault_secret" "test" {
-  name              = "secret-%s"
-  value_wo          = "%s"
-  value_wo_version  = %d
-  key_vault_id      = azurerm_key_vault.test.id
+  name             = "secret-%s"
+  value_wo         = "%s"
+  value_wo_version = %d
+  key_vault_id     = azurerm_key_vault.test.id
 }
 `, r.template(data), data.RandomString, secret, version)
 }

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -75,7 +75,13 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.
 
-* `value` - (Required) Specifies the value of the Key Vault Secret. Changing this will create a new version of the Key Vault Secret.
+* `value` - (Optional) Specifies the value of the Key Vault Secret. Changing this will create a new version of the Key Vault Secret.
+
+* `value_wo` - (Optional, Write-Only) Specifies the value of the Key Vault Secret. Changing this will create a new version of the Key Vault Secret.
+
+* ~> **Note:** Either `value` or `value_wo` is required.
+
+* `value_wo_version` - (Optional) An integer value used to trigger an update for `value_wo`. This property should be incremented when updating `value_wo`.
 
 ~> **Note:** Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with `\n` or by base 64 encoding them with `replace(file("my_secret_file"), "/\n/", "\n")` or `base64encode(file("my_secret_file"))`, respectively.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `value_wo` - (Optional, Write-Only) Specifies the value of the Key Vault Secret. Changing this will create a new version of the Key Vault Secret.
 
-* ~> **Note:** Either `value` or `value_wo` is required.
+* ~> **Note:** One of `value` or `value_wo` must be specified.
 
 * `value_wo_version` - (Optional) An integer value used to trigger an update for `value_wo`. This property should be incremented when updating `value_wo`.
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds write-only functionality to key vault secrets. 

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide]
TestAccKeyVaultSecret_disappearsWhenParentKeyVaultDeleted failed for me prior to doing any changes so I skipped this test. 

```
make acctests SERVICE="keyvault" TESTARGS='-skip=disappearsWhenParentKeyVaultDeleted -run=TestAccKeyVaultSecret'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault -skip=disappearsWhenParentKeyVaultDeleted -run=TestAccKeyVaultSecret -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVaultSecret_basic
=== PAUSE TestAccKeyVaultSecret_basic
=== RUN   TestAccKeyVaultSecret_writeOnlyValue
=== PAUSE TestAccKeyVaultSecret_writeOnlyValue
=== RUN   TestAccKeyVaultSecret_updateToWriteOnlyValue
=== PAUSE TestAccKeyVaultSecret_updateToWriteOnlyValue
=== RUN   TestAccKeyVaultSecret_requiresImport
=== PAUSE TestAccKeyVaultSecret_requiresImport
=== RUN   TestAccKeyVaultSecret_disappears
=== PAUSE TestAccKeyVaultSecret_disappears
=== RUN   TestAccKeyVaultSecret_complete
=== PAUSE TestAccKeyVaultSecret_complete
=== RUN   TestAccKeyVaultSecret_update
=== PAUSE TestAccKeyVaultSecret_update
=== RUN   TestAccKeyVaultSecret_updatingValueChangedExternally
=== PAUSE TestAccKeyVaultSecret_updatingValueChangedExternally
=== RUN   TestAccKeyVaultSecret_recovery
=== PAUSE TestAccKeyVaultSecret_recovery
=== RUN   TestAccKeyVaultSecret_withExternalAccessPolicy
=== PAUSE TestAccKeyVaultSecret_withExternalAccessPolicy
=== RUN   TestAccKeyVaultSecret_purge
=== PAUSE TestAccKeyVaultSecret_purge
=== CONT  TestAccKeyVaultSecret_basic
=== CONT  TestAccKeyVaultSecret_update
=== CONT  TestAccKeyVaultSecret_withExternalAccessPolicy
=== CONT  TestAccKeyVaultSecret_requiresImport
=== CONT  TestAccKeyVaultSecret_recovery
=== CONT  TestAccKeyVaultSecret_updateToWriteOnlyValue
=== CONT  TestAccKeyVaultSecret_updatingValueChangedExternally
=== CONT  TestAccKeyVaultSecret_complete
=== CONT  TestAccKeyVaultSecret_disappears
=== CONT  TestAccKeyVaultSecret_writeOnlyValue
=== CONT  TestAccKeyVaultSecret_purge
--- PASS: TestAccKeyVaultSecret_disappears (818.77s)
--- PASS: TestAccKeyVaultSecret_writeOnlyValue (841.80s)
--- PASS: TestAccKeyVaultSecret_purge (843.25s)
--- PASS: TestAccKeyVaultSecret_requiresImport (843.62s)
--- PASS: TestAccKeyVaultSecret_updateToWriteOnlyValue (850.45s)
--- PASS: TestAccKeyVaultSecret_basic (851.84s)
--- PASS: TestAccKeyVaultSecret_update (855.21s)
--- PASS: TestAccKeyVaultSecret_complete (858.88s)
--- PASS: TestAccKeyVaultSecret_updatingValueChangedExternally (876.93s)
--- PASS: TestAccKeyVaultSecret_withExternalAccessPolicy (893.26s)
--- PASS: TestAccKeyVaultSecret_recovery (1046.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      1048.269s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

* `azurerm_key_vault_secret` - support for the `value_wo` and `value_wo_version` property [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
